### PR TITLE
fix 챗봇 페이지 모바일 사이드바 버그 해결, 모바일 요소 넘침 해결

### DIFF
--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -288,6 +288,7 @@ const removeImage = (index: number) => {
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: space-between;
   gap: 12px;
   max-width: min(770px, 100%);
   width: 100%;
@@ -651,8 +652,8 @@ textarea:disabled {
 /* 태블릿 (641px - 1024px) */
 @media (min-width: 641px) and (max-width: 1024px) {
   .chat-input-box {
-    max-width: 500px;
-    width: 500px;
+    /* max-width: 500px; */
+    width : 90%;
   }
 
   .placeholder-text-container {

--- a/src/components/chat/index.vue
+++ b/src/components/chat/index.vue
@@ -68,7 +68,7 @@
     
     <div class="sidebar-collapsible-ct" v-show=showFixedContent>
       <div>
-      <img :src="eulLogo" alt="EULGPT 로고" @click="goToHome" class="eulgpt-logo-svg" />
+      <img v-if="!isMobile" :src="eulLogo" alt="EULGPT 로고" @click="goToHome" class="eulgpt-logo-svg" />
       <div class="edit-icon" @click="startNewChat"></div>
       </div>
     </div>
@@ -150,7 +150,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onUnmounted, nextTick, watch  } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import ChatHistory from './ChatHistory.vue';
 import ChatMessageArea from './ChatMessageArea.vue';
@@ -348,6 +348,19 @@ const handleRetryMessage = (messageIndex: number) => {
 log.debug('Current messages:', messages.value);
 
 const isMobile = ref(false);
+
+watch(isMobile, (newVal) => {
+  if (newVal) {
+    isCollapsed.value = false;
+    showCollapsibleContent.value = true;
+    showFixedContent.value = false;
+    sidebarVisible.value = true; 
+  } else {
+    sidebarVisible.value = true;
+  }
+});
+
+
 const sidebarVisible = ref(true);
 const sidebarWidth = ref(Number(localStorage.getItem('sidebarWidth')) || 270);
 
@@ -707,9 +720,19 @@ const isCollapsed = ref(false);
 
 // pc 사이드바 토글 함수 설정
 const pctoggleSidebar = () => {
-  showCollapsibleContent.value = !showCollapsibleContent.value;
-  showFixedContent.value = !showFixedContent.value;
-  isCollapsed.value = !isCollapsed.value;
+  if (isMobile.value) {
+    sidebarVisible.value = !sidebarVisible.value;
+
+    if (sidebarVisible.value) {
+      showCollapsibleContent.value = true;
+      showFixedContent.value = false;
+      isCollapsed.value = false;
+    }
+  } else {
+    showCollapsibleContent.value = !showCollapsibleContent.value;
+    showFixedContent.value = !showFixedContent.value;
+    isCollapsed.value = !isCollapsed.value;
+  }
 };
 
 const toggleSidebar = () => {
@@ -918,7 +941,7 @@ const goToCrew = () => {
   border-right: 1px solid var(--color-card-border);
   min-width: 200px;
   max-width: 500px;
-  border-radius: 20px;
+  border-radius: 0px 20px 20px 0px;
   box-shadow:
     inset 0px 0px 6px 0px rgba(255, 255, 255, 0.15),
     inset 2px 2px 4px 0px rgba(255, 255, 255, 0.96),
@@ -1642,6 +1665,9 @@ const goToCrew = () => {
   /* 480px 이하에서도 키보드 대응 유지 */
   .chat-input-area {
     padding-bottom: max(env(safe-area-inset-bottom), var(--keyboard-height, 0px));
+  }
+  .chatbot-sidebar-wrapper {
+    border-radius: 0px;
   }
 }
 


### PR DESCRIPTION
챗봇 모바일에서 사이드바 클릭시 PC 버전 사이드바 펼침, 접힘 상태가 지속되는 버그 수정, 사이드바 접힘 상태에서 모바일 반응형 테스트시 사이드바가 정상적으로 나오지 않는 버그 수정, 모바일 챗봇 화면에서 사용자 입력창이 요소보다 넘치는 문제 해결